### PR TITLE
Gcs events

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,12 +44,12 @@
         <dependency>
             <groupId>no.ssb.dapla</groupId>
             <artifactId>metadata-distributor-protobuf</artifactId>
-            <version>0.2-SNAPSHOT</version>
+            <version>0.2</version>
         </dependency>
         <dependency>
             <groupId>no.ssb.helidon</groupId>
             <artifactId>helidon-application</artifactId>
-            <version>0.4-SNAPSHOT</version>
+            <version>0.3.2</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>no.ssb.helidon</groupId>
             <artifactId>helidon-testing</artifactId>
-            <version>0.5-SNAPSHOT</version>
+            <version>0.5</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,11 @@
             <version>0.2-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>no.ssb.helidon</groupId>
+            <artifactId>helidon-application</artifactId>
+            <version>0.4-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-pubsub</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <dependency>
             <groupId>no.ssb.dapla</groupId>
             <artifactId>metadata-distributor-protobuf</artifactId>
+            <version>0.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
@@ -52,6 +53,7 @@
         <dependency>
             <groupId>no.ssb.pubsub</groupId>
             <artifactId>google-pubsub-client</artifactId>
+            <version>0.7</version>
         </dependency>
         <dependency>
             <groupId>no.ssb.dapla</groupId>
@@ -60,6 +62,12 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-storage</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>no.ssb.helidon</groupId>
+            <artifactId>helidon-testing</artifactId>
+            <version>0.5-SNAPSHOT</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/run.sh
+++ b/run.sh
@@ -3,12 +3,20 @@
 export JPMS_SWITCHES="
   --add-exports=io.grpc/io.opencensus.common=gax
   --add-exports=io.grpc/io.opencensus.trace=gax
-  --add-exports=io.grpc/io.opencensus.trace=com.google.api.client
-  --add-exports=io.grpc/io.opencensus.trace.propagation=com.google.api.client
-  --add-exports=io.grpc/io.opencensus.trace.export=com.google.api.client
+  --add-exports=io.grpc/io.opencensus.trace.export=gax
+  --add-exports=io.grpc/io.opencensus.trace.propagation=gax
   --add-exports=io.grpc/io.opencensus.common=com.google.api.client
-  --add-exports=io.grpc/io.opencensus.trace.propagation=opencensus.contrib.http.util
+  --add-exports=io.grpc/io.opencensus.trace=com.google.api.client
+  --add-exports=io.grpc/io.opencensus.trace.export=com.google.api.client
+  --add-exports=io.grpc/io.opencensus.trace.propagation=com.google.api.client
+  --add-exports=io.grpc/io.opencensus.common=google.cloud.storage
+  --add-exports=io.grpc/io.opencensus.trace=google.cloud.storage
+  --add-exports=io.grpc/io.opencensus.trace.export=google.cloud.storage
+  --add-exports=io.grpc/io.opencensus.trace.propagation=google.cloud.storage
+  --add-exports=io.grpc/io.opencensus.common=opencensus.contrib.http.util
   --add-exports=io.grpc/io.opencensus.trace=opencensus.contrib.http.util
+  --add-exports=io.grpc/io.opencensus.trace.export=opencensus.contrib.http.util
+  --add-exports=io.grpc/io.opencensus.trace.propagation=opencensus.contrib.http.util
 "
 
 if [ "$JAVA_MODULE_SYSTEM_ENABLED" == "true" ]; then

--- a/src/main/java/no/ssb/dapla/metadata/distributor/MetadataDistributorApplication.java
+++ b/src/main/java/no/ssb/dapla/metadata/distributor/MetadataDistributorApplication.java
@@ -108,7 +108,8 @@ public class MetadataDistributorApplication extends DefaultHelidonApplication {
         MetadataDistributorGrpcService distributorGrpcService = new MetadataDistributorGrpcService(pubSub);
         put(MetadataDistributorGrpcService.class, distributorGrpcService);
 
-        Storage storage = createStorage(config.get("cloud-storage"));
+        Storage storage = createStorage(config.get("storage.cloud-storage"));
+        put(Storage.class, storage);
 
         if (config.get("pubsub.admin").asBoolean().orElse(false)) {
             config.get("pubsub.metadata-routing").asNodeList().get().stream().forEach(routing -> {
@@ -116,8 +117,9 @@ public class MetadataDistributorApplication extends DefaultHelidonApplication {
             });
         }
 
+        String fileSystemPathPrefix = config.get("storage.file-system.path-prefix").asString().get();
         config.get("pubsub.metadata-routing").asNodeList().get().stream().forEach(routing -> {
-            metadataRouters.add(new MetadataRouter(routing, pubSub, storage, metadataSignatureVerifier));
+            metadataRouters.add(new MetadataRouter(routing, pubSub, storage, metadataSignatureVerifier, fileSystemPathPrefix));
         });
 
         GrpcServer grpcServer = GrpcServer.create(

--- a/src/main/java/no/ssb/dapla/metadata/distributor/MetadataDistributorApplication.java
+++ b/src/main/java/no/ssb/dapla/metadata/distributor/MetadataDistributorApplication.java
@@ -109,7 +109,9 @@ public class MetadataDistributorApplication extends DefaultHelidonApplication {
         put(MetadataDistributorGrpcService.class, distributorGrpcService);
 
         Storage storage = createStorage(config.get("storage.cloud-storage"));
-        put(Storage.class, storage);
+        if (storage != null) {
+            put(Storage.class, storage);
+        }
 
         if (config.get("pubsub.admin").asBoolean().orElse(false)) {
             config.get("pubsub.metadata-routing").asNodeList().get().stream().forEach(routing -> {
@@ -117,9 +119,8 @@ public class MetadataDistributorApplication extends DefaultHelidonApplication {
             });
         }
 
-        String fileSystemPathPrefix = config.get("storage.file-system.path-prefix").asString().get();
         config.get("pubsub.metadata-routing").asNodeList().get().stream().forEach(routing -> {
-            metadataRouters.add(new MetadataRouter(routing, pubSub, storage, metadataSignatureVerifier, fileSystemPathPrefix));
+            metadataRouters.add(new MetadataRouter(routing, pubSub, storage, metadataSignatureVerifier));
         });
 
         GrpcServer grpcServer = GrpcServer.create(

--- a/src/main/java/no/ssb/dapla/metadata/distributor/MetadataDistributorApplication.java
+++ b/src/main/java/no/ssb/dapla/metadata/distributor/MetadataDistributorApplication.java
@@ -22,6 +22,7 @@ import io.helidon.webserver.WebTracingConfig;
 import io.helidon.webserver.accesslog.AccessLogSupport;
 import io.opentracing.Tracer;
 import io.opentracing.contrib.grpc.OperationNameConstructor;
+import no.ssb.dapla.metadata.distributor.dataset.DefaultMetadataSignatureVerifier;
 import no.ssb.dapla.metadata.distributor.dataset.MetadataDistributorGrpcService;
 import no.ssb.dapla.metadata.distributor.dataset.MetadataRouter;
 import no.ssb.dapla.metadata.distributor.dataset.MetadataRouterTopicAndSubscriptionInitialization;
@@ -90,13 +91,18 @@ public class MetadataDistributorApplication extends DefaultHelidonApplication {
         PubSub pubSub = createPubSub(config.get("pubsub"));
         put(PubSub.class, pubSub);
 
+        MetadataSignatureVerifier metadataSignatureVerifier;
         Config signerConfig = config.get("metadatads");
-        String keystoreFormat = signerConfig.get("format").asString().get();
-        String keystore = signerConfig.get("keystore").asString().get();
-        String keyAlias = signerConfig.get("keyAlias").asString().get();
-        char[] password = signerConfig.get("password").asString().get().toCharArray();
-        String algorithm = signerConfig.get("algorithm").asString().get();
-        MetadataSignatureVerifier metadataSignatureVerifier = new MetadataSignatureVerifier(keystoreFormat, keystore, keyAlias, password, algorithm);
+        if (signerConfig.get("bypass-validation").asBoolean().orElse(false)) {
+            metadataSignatureVerifier = (data, receivedSign) -> true; // always accept signature
+        } else {
+            String keystoreFormat = signerConfig.get("format").asString().get();
+            String keystore = signerConfig.get("keystore").asString().get();
+            String keyAlias = signerConfig.get("keyAlias").asString().get();
+            char[] password = signerConfig.get("password").asString().get().toCharArray();
+            String algorithm = signerConfig.get("algorithm").asString().get();
+            metadataSignatureVerifier = new DefaultMetadataSignatureVerifier(keystoreFormat, keystore, keyAlias, password, algorithm);
+        }
         put(MetadataSignatureVerifier.class, metadataSignatureVerifier);
 
         MetadataDistributorGrpcService distributorGrpcService = new MetadataDistributorGrpcService(pubSub);

--- a/src/main/java/no/ssb/dapla/metadata/distributor/dataset/DefaultMetadataSignatureVerifier.java
+++ b/src/main/java/no/ssb/dapla/metadata/distributor/dataset/DefaultMetadataSignatureVerifier.java
@@ -1,0 +1,40 @@
+package no.ssb.dapla.metadata.distributor.dataset;
+
+import java.io.FileInputStream;
+import java.security.KeyStore;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.SignatureException;
+import java.security.cert.Certificate;
+
+public class DefaultMetadataSignatureVerifier implements MetadataSignatureVerifier {
+
+    final Signature signature;
+
+    public DefaultMetadataSignatureVerifier(String keystoreFormat, String keystorePath, String keyAlias, char[] password, String algorithm) {
+        try {
+            KeyStore keyStore = KeyStore.getInstance(keystoreFormat);
+            keyStore.load(new FileInputStream(keystorePath), password);
+            Certificate certificate = keyStore.getCertificate(keyAlias);
+            PublicKey publicKey = certificate.getPublicKey();
+
+            signature = Signature.getInstance(algorithm);
+            signature.initVerify(publicKey);
+        } catch (Error | RuntimeException e) {
+            throw e;
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
+    @Override
+    public boolean verify(byte[] data, byte[] receivedSign) {
+        try {
+            signature.update(data);
+            return signature.verify(receivedSign);
+        } catch (SignatureException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/main/java/no/ssb/dapla/metadata/distributor/dataset/MetadataDistributorGrpcService.java
+++ b/src/main/java/no/ssb/dapla/metadata/distributor/dataset/MetadataDistributorGrpcService.java
@@ -1,10 +1,14 @@
 package no.ssb.dapla.metadata.distributor.dataset;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutureCallback;
 import com.google.api.core.ApiFutures;
 import com.google.cloud.pubsub.v1.Publisher;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.ProjectTopicName;
 import com.google.pubsub.v1.PubsubMessage;
 import io.grpc.stub.StreamObserver;
@@ -18,6 +22,8 @@ import no.ssb.pubsub.PubSub;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -32,6 +38,7 @@ public class MetadataDistributorGrpcService extends MetadataDistributorServiceGr
 
     final PubSub pubSub;
     final Map<ProjectTopicName, Publisher> publisherByProjectTopicName = new ConcurrentHashMap<>();
+    final ObjectMapper mapper = new ObjectMapper();
 
     public MetadataDistributorGrpcService(PubSub pubSub) {
         this.pubSub = pubSub;
@@ -48,16 +55,40 @@ public class MetadataDistributorGrpcService extends MetadataDistributorServiceGr
                 LOG.info("Creating publisher on topic: {}", ptn.toString());
                 return pubSub.getPublisher(projectId, topicName);
             });
-            PubsubMessage message = PubsubMessage.newBuilder().setData(request.toByteString()).build();
+
+            URI uri = new URI(request.getUri());
+
+            ObjectNode dataNode = mapper.createObjectNode();
+            if ("gs".equals(uri.getScheme())) {
+                dataNode.put("kind", "storage#object");
+                dataNode.put("id", uri.getHost() + "/" + uri.getPath());
+                dataNode.put("bucket", uri.getHost());
+                dataNode.put("name", uri.getPath());
+            } else if ("file".equals(uri.getScheme())) {
+                dataNode.put("kind", "filesystem");
+                dataNode.put("id", uri.getPath());
+                dataNode.put("name", uri.getPath());
+            }
+
+            PubsubMessage message = PubsubMessage.newBuilder()
+                    .putAllAttributes(Map.of(
+                            "eventType", "OBJECT_FINALIZE",
+                            "payloadFormat", "DAPLA_JSON_API_V1",
+                            "bucketId", uri.getHost(),
+                            "objectId", uri.getPath()
+                    ))
+                    .setData(ByteString.copyFrom(mapper.writeValueAsBytes(dataNode)))
+                    .build();
+
             ApiFuture<String> publishResponseFuture = publisher.publish(message); // async
+
             ApiFutures.addCallback(publishResponseFuture, new ApiFutureCallback<>() {
                 @Override
                 public void onSuccess(String messageId) {
                     try {
                         restoreTracingContext(tracerAndSpan);
-                        String txId = messageId;
                         span.log(Map.of("event", "successfully published message", "messageId", messageId));
-                        responseObserver.onNext(DataChangedResponse.newBuilder().setTxId(txId).build());
+                        responseObserver.onNext(DataChangedResponse.newBuilder().setMessageId(messageId).build());
                         responseObserver.onCompleted();
                     } finally {
                         span.finish();
@@ -76,7 +107,7 @@ public class MetadataDistributorGrpcService extends MetadataDistributorServiceGr
                     }
                 }
             }, MoreExecutors.directExecutor());
-        } catch (RuntimeException | Error e) {
+        } catch (RuntimeException | Error | URISyntaxException | JsonProcessingException e) {
             try {
                 Tracing.logError(span, e);
                 LOG.error("unexpected error", e);

--- a/src/main/java/no/ssb/dapla/metadata/distributor/dataset/MetadataSignatureVerifier.java
+++ b/src/main/java/no/ssb/dapla/metadata/distributor/dataset/MetadataSignatureVerifier.java
@@ -1,39 +1,6 @@
 package no.ssb.dapla.metadata.distributor.dataset;
 
-import java.io.FileInputStream;
-import java.security.KeyStore;
-import java.security.PublicKey;
-import java.security.Signature;
-import java.security.SignatureException;
-import java.security.cert.Certificate;
+public interface MetadataSignatureVerifier {
 
-public class MetadataSignatureVerifier {
-
-    final Signature signature;
-
-    public MetadataSignatureVerifier(String keystoreFormat, String keystorePath, String keyAlias, char[] password, String algorithm) {
-        try {
-            KeyStore keyStore = KeyStore.getInstance(keystoreFormat);
-            keyStore.load(new FileInputStream(keystorePath), password);
-            Certificate certificate = keyStore.getCertificate(keyAlias);
-            PublicKey publicKey = certificate.getPublicKey();
-
-            signature = Signature.getInstance(algorithm);
-            signature.initVerify(publicKey);
-        } catch (Error | RuntimeException e) {
-            throw e;
-        } catch (Throwable t) {
-            throw new RuntimeException(t);
-        }
-    }
-
-    public boolean verify(byte[] data, byte[] receivedSign) {
-        try {
-            signature.update(data);
-            return signature.verify(receivedSign);
-        } catch (SignatureException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
+    boolean verify(byte[] data, byte[] receivedSign);
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,6 +13,7 @@ tracing:
   service: metadata-distributor
   sampler-type: const
   sampler-param: 1
+  propagation: b3
   protocol: http
   host: localhost
   port: 14268
@@ -22,7 +23,17 @@ tracing:
       enabled: false
     - path: "/metrics"
       enabled: false
+    - path: "/metrics/vendor"
+      enabled: false
+    - path: "/metrics/base"
+      enabled: false
+    - path: "/metrics/application"
+      enabled: false
     - path: "/health"
+      enabled: false
+    - path: "/health/live"
+      enabled: false
+    - path: "/health/ready"
       enabled: false
 
 pubsub:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -54,6 +54,7 @@ pubsub:
         - projectId: dapla
           topic: file-events-1
           subscription: metadata-distributor-catalog
+          subscribe: true
           ack-deadline-seconds: 30
           dlq:
             projectId: dapla
@@ -64,16 +65,20 @@ pubsub:
         - projectId: dapla
           topic: catalog-1
 
-cloud-storage:
-  enabled: false
-  credential-provider: service-account
-  credentials:
-    service-account:
-      path: secret/my-service-account-key.json
-    compute-engine:
-    default:
+storage:
+  file-system:
+    path-prefix: /data
+  cloud-storage:
+    enabled: false
+    credential-provider: service-account
+    credentials:
+      service-account:
+        path: secret/my-service-account-key.json
+      compute-engine:
+      default:
 
 metadatads:
+  bypass-validation: false
   format: PKCS12
   keystore: secret/metadata-verifier_keystore.p12
   keyAlias: dataAccessCertificate

--- a/src/test/java/no/ssb/dapla/metadata/distributor/dataset/DefaultMetadataSignatureVerifierTest.java
+++ b/src/test/java/no/ssb/dapla/metadata/distributor/dataset/DefaultMetadataSignatureVerifierTest.java
@@ -6,9 +6,9 @@ import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class MetadataSignatureVerifierTest {
+class DefaultMetadataSignatureVerifierTest {
 
-    MetadataSignatureVerifier metadataSignatureVerifier = new MetadataSignatureVerifier(
+    MetadataSignatureVerifier metadataSignatureVerifier = new DefaultMetadataSignatureVerifier(
             "PKCS12",
             "src/test/resources/metadata-verifier_keystore.p12",
             "dataAccessCertificate",

--- a/src/test/java/no/ssb/dapla/metadata/distributor/dataset/FilesystemMetadataPropagationTest.java
+++ b/src/test/java/no/ssb/dapla/metadata/distributor/dataset/FilesystemMetadataPropagationTest.java
@@ -1,0 +1,153 @@
+package no.ssb.dapla.metadata.distributor.dataset;
+
+import com.google.api.core.ApiService;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
+import com.google.cloud.pubsub.v1.TopicAdminClient;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.protobuf.ByteString;
+import io.grpc.Channel;
+import no.ssb.dapla.dataset.api.DatasetId;
+import no.ssb.dapla.dataset.api.DatasetMeta;
+import no.ssb.dapla.dataset.api.PseudoConfig;
+import no.ssb.dapla.metadata.distributor.MetadataDistributorApplication;
+import no.ssb.dapla.metadata.distributor.protobuf.DataChangedRequest;
+import no.ssb.dapla.metadata.distributor.protobuf.DataChangedResponse;
+import no.ssb.dapla.metadata.distributor.protobuf.MetadataDistributorServiceGrpc;
+import no.ssb.dapla.metadata.distributor.protobuf.MetadataDistributorServiceGrpc.MetadataDistributorServiceBlockingStub;
+import no.ssb.helidon.media.protobuf.ProtobufJsonUtils;
+import no.ssb.pubsub.PubSub;
+import no.ssb.pubsub.PubSubAdmin;
+import no.ssb.testing.helidon.IntegrationTestExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(IntegrationTestExtension.class)
+class FilesystemMetadataPropagationTest {
+
+    @Inject
+    MetadataDistributorApplication application;
+
+    @Inject
+    Channel channel;
+
+    @Test
+    void thatThisWorks() throws IOException, InterruptedException {
+        initTopicAndSubscription("dapla", "catalog-1", "catalog-1-junit");
+
+        MetadataDistributorServiceBlockingStub distributor = MetadataDistributorServiceGrpc.newBlockingStub(channel);
+
+        String dataFolder = System.getProperty("user.dir") + "/target/data";
+        DatasetMeta datasetMeta = createDatasetMeta(dataFolder, 0);
+        writeDatasetMetaFile(datasetMeta);
+        String metadataPath = datasetMeta.getId().getPath() + "/" + datasetMeta.getId().getVersion() + "/.dataset-meta.json";
+        DataChangedRequest request = DataChangedRequest.newBuilder()
+                .setProjectId("dapla")
+                .setTopicName("file-events-1")
+                .setUri(datasetMeta.getParentUri() + metadataPath)
+                .build();
+        DataChangedResponse response = distributor.dataChanged(request);
+        assertThat(response.getMessageId()).isNotNull();
+
+        ByteString validMetadataJson = ByteString.copyFromUtf8(ProtobufJsonUtils.toString(datasetMeta));
+        MetadataSigner metadataSigner = new MetadataSigner("PKCS12", "src/test/resources/metadata-signer_keystore.p12",
+                "dataAccessKeyPair", "changeit".toCharArray(), "SHA256withRSA");
+        byte[] signature = metadataSigner.sign(validMetadataJson.toByteArray());
+        writeSignatureFile(datasetMeta, signature);
+        String metadataSignaturePath = datasetMeta.getId().getPath() + "/" + datasetMeta.getId().getVersion() + "/.dataset-meta.json.sign";
+        DataChangedRequest signatureRequest = DataChangedRequest.newBuilder()
+                .setProjectId("dapla")
+                .setTopicName("file-events-1")
+                .setUri(datasetMeta.getParentUri() + metadataSignaturePath)
+                .build();
+        DataChangedResponse signatureResponse = distributor.dataChanged(signatureRequest);
+        assertThat(signatureResponse.getMessageId()).isNotNull();
+
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        MessageReceiver messageReceiver = (message, consumer) -> {
+            try {
+                DatasetMeta propagatedMetadata = ProtobufJsonUtils.toPojo(message.getData().toStringUtf8(), DatasetMeta.class);
+                System.out.format("Received message in junit test: %s%n", propagatedMetadata);
+                if (propagatedMetadata.equals(datasetMeta)) {
+                    latch.countDown();
+                }
+            } catch (Throwable t) {
+                t.printStackTrace();
+            } finally {
+                consumer.ack();
+            }
+        };
+
+        PubSub pubSub = application.get(PubSub.class);
+        Subscriber subscriber = pubSub.getSubscriber("dapla", "catalog-1-junit", messageReceiver);
+        subscriber.addListener(
+                new Subscriber.Listener() {
+                    public void failed(Subscriber.State from, Throwable failure) {
+                        System.out.println("Error with subscriber");
+                    }
+                },
+                MoreExecutors.directExecutor());
+        ApiService subscriberStartAsyncApiService = subscriber.startAsync();
+
+        subscriberStartAsyncApiService.awaitRunning();
+
+        assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
+    }
+
+    private void initTopicAndSubscription(String projectId, String topic, String subscription) {
+        PubSub pubSub = application.get(PubSub.class);
+        try (TopicAdminClient topicAdminClient = pubSub.getTopicAdminClient()) {
+            PubSubAdmin.createTopicIfNotExists(topicAdminClient, projectId, topic);
+            try (SubscriptionAdminClient subscriptionAdminClient = pubSub.getSubscriptionAdminClient()) {
+                PubSubAdmin.createSubscriptionIfNotExists(subscriptionAdminClient, projectId, topic, subscription, 60);
+            }
+        }
+    }
+
+    private DatasetMeta createDatasetMeta(String dataFolder, int i) {
+        String parentUri = "file:" + dataFolder;
+        String path = "/path/to/dataset-" + i;
+        long version = System.currentTimeMillis();
+        return DatasetMeta.newBuilder()
+                .setId(DatasetId.newBuilder()
+                        .setPath(path)
+                        .setVersion(version)
+                        .build())
+                .setType(DatasetMeta.Type.BOUNDED)
+                .setValuation(DatasetMeta.Valuation.OPEN)
+                .setState(DatasetMeta.DatasetState.INPUT)
+                .setParentUri(parentUri)
+                .setPseudoConfig(PseudoConfig.newBuilder().build())
+                .setCreatedBy("junit")
+                .build();
+    }
+
+    private void writeDatasetMetaFile(DatasetMeta datasetMeta) throws IOException {
+        String dataFolder = datasetMeta.getParentUri().substring("file:".length());
+        Path datasetMetaJsonPath = Path.of(dataFolder + datasetMeta.getId().getPath() + "/" + datasetMeta.getId().getVersion() + "/.dataset-meta.json");
+        Files.createDirectories(datasetMetaJsonPath.getParent());
+        String datasetMetaJson = ProtobufJsonUtils.toString(datasetMeta);
+        Files.writeString(datasetMetaJsonPath, datasetMetaJson, StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
+    }
+
+    private void writeSignatureFile(DatasetMeta datasetMeta, byte[] signature) throws IOException {
+        String dataFolder = datasetMeta.getParentUri().substring("file:".length());
+        Path datasetMetaJsonPath = Path.of(dataFolder + datasetMeta.getId().getPath() + "/" + datasetMeta.getId().getVersion() + "/.dataset-meta.json.sign");
+        Files.createDirectories(datasetMetaJsonPath.getParent());
+        Files.write(datasetMetaJsonPath, signature, StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
+    }
+}

--- a/src/test/java/no/ssb/dapla/metadata/distributor/dataset/MetadataRouterGCSEventTest.java
+++ b/src/test/java/no/ssb/dapla/metadata/distributor/dataset/MetadataRouterGCSEventTest.java
@@ -82,15 +82,12 @@ public class MetadataRouterGCSEventTest {
         String upstreamSubscriptionName = "md-test-up-gcs";
 
         CountDownLatch latch = new CountDownLatch(2);
-        String fileSystemPathPrefix = System.getenv("user.dir") + "/target/data";
 
         MessageReceiver messageReceiver = (message, consumer) -> {
             try {
                 System.out.printf("message: %s%n", message);
 
-                MetadataRouter.process(storage, metadataSignatureVerifier, Collections.emptyList(), upstreamTopicName, upstreamSubscriptionName, message, () -> {
-                    consumer.ack();
-                }, fileSystemPathPrefix);
+                MetadataRouter.process(storage, metadataSignatureVerifier, Collections.emptyList(), upstreamTopicName, upstreamSubscriptionName, message, consumer::ack);
 
                 Map<String, String> attributes = message.getAttributesMap();
                 String objectId = attributes.get("objectId");

--- a/src/test/java/no/ssb/dapla/metadata/distributor/dataset/MetadataRouterGCSEventTest.java
+++ b/src/test/java/no/ssb/dapla/metadata/distributor/dataset/MetadataRouterGCSEventTest.java
@@ -1,0 +1,123 @@
+package no.ssb.dapla.metadata.distributor.dataset;
+
+import com.google.api.core.ApiService;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageClass;
+import com.google.common.util.concurrent.MoreExecutors;
+import no.ssb.dapla.dataset.api.DatasetMeta;
+import no.ssb.dapla.metadata.distributor.MetadataDistributorApplication;
+import no.ssb.helidon.media.protobuf.ProtobufJsonUtils;
+import no.ssb.pubsub.PubSub;
+import no.ssb.testing.helidon.ConfigOverride;
+import no.ssb.testing.helidon.IntegrationTestExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.inject.Inject;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+@ConfigOverride({
+        "pubsub.use-emulator", "false",
+        "pubsub.credential-provider", "service-account",
+        "pubsub.credentials.service-account.path", "secret/dev-sirius-37ed83f3c726.json",
+        "pubsub.admin", "false",
+        "pubsub.metadata-routing.0.upstream.0.projectId", "dev-sirius",
+        "pubsub.metadata-routing.0.upstream.0.topic", "md-test-up",
+        "pubsub.metadata-routing.0.upstream.0.subscription", "md-test-up-gcs",
+        "pubsub.metadata-routing.0.upstream.0.subscribe", "false",
+        "pubsub.metadata-routing.0.upstream.0.ack-deadline-seconds", "30",
+        "pubsub.metadata-routing.0.upstream.0.dlq.projectId", "dev-sirius",
+        "pubsub.metadata-routing.0.upstream.0.dlq.topic", "md-test-up-dlq",
+        "pubsub.metadata-routing.0.upstream.0.dlq.max-redelivery-attempts", "5",
+        "pubsub.metadata-routing.0.upstream.0.dlq.subscription", "md-test-up-dlq-errors",
+        "pubsub.metadata-routing.0.downstream.0.projectId", "dev-sirius",
+        "pubsub.metadata-routing.0.downstream.0.topic", "md-test-down",
+        "storage.cloud-storage.enabled", "true",
+        "storage.cloud-storage.credential-provider", "service-account",
+        "storage.cloud-storage.credentials.service-account.path", "secret/dev-sirius-37ed83f3c726.json",
+})
+@ExtendWith(IntegrationTestExtension.class)
+public class MetadataRouterGCSEventTest {
+
+    @Inject
+    MetadataDistributorApplication application;
+
+    @Test
+    public void thatGCSEventCanBeParsed() throws InterruptedException {
+        Storage storage = application.get(Storage.class);
+        PubSub pubSub = application.get(PubSub.class);
+        MetadataSignatureVerifier metadataSignatureVerifier = (data, receivedSign) -> true;
+
+        String bucketName = "ssb-dev-md-test";
+
+        if (storage.get(bucketName) == null) {
+            Bucket bucket = storage.create(BucketInfo.newBuilder(bucketName)
+                    .setStorageClass(StorageClass.STANDARD)
+                    .setLocation("EUROPE-NORTH1")
+                    .build());
+            System.out.printf("Bucket %s created.%n", bucket.getName());
+        }
+
+        long version = System.currentTimeMillis();
+
+        System.out.printf("Publishing two files under version folder: %d%n", version);
+
+        String metadataPath = String.format("%s/%d/%s", "md-junit-test", version, ".dataset-meta.json");
+        String metadataSignaturePath = String.format("%s/%d/%s", "md-junit-test", version, ".dataset-meta.json.sign");
+
+        storage.create(BlobInfo.newBuilder(BucketInfo.of(bucketName), metadataPath).build(), ProtobufJsonUtils.toString(DatasetMeta.newBuilder().build()).getBytes(StandardCharsets.UTF_8));
+        storage.create(BlobInfo.newBuilder(BucketInfo.of(bucketName), metadataSignaturePath).build(), "My Signature".getBytes(StandardCharsets.UTF_8));
+
+        String upstreamProjectId = "dev-sirius";
+        String upstreamTopicName = "md-test-up";
+        String upstreamSubscriptionName = "md-test-up-gcs";
+
+        CountDownLatch latch = new CountDownLatch(2);
+        String fileSystemPathPrefix = System.getenv("user.dir") + "/target/data";
+
+        MessageReceiver messageReceiver = (message, consumer) -> {
+            try {
+                System.out.printf("message: %s%n", message);
+
+                MetadataRouter.process(storage, metadataSignatureVerifier, Collections.emptyList(), upstreamTopicName, upstreamSubscriptionName, message, () -> {
+                    consumer.ack();
+                }, fileSystemPathPrefix);
+
+                Map<String, String> attributes = message.getAttributesMap();
+                String objectId = attributes.get("objectId");
+                if (metadataPath.equals(objectId)) {
+                    latch.countDown();
+                } else if (metadataSignaturePath.equals(objectId)) {
+                    latch.countDown();
+                }
+            } catch (Throwable t) {
+                t.printStackTrace();
+            }
+        };
+
+        Subscriber subscriber = pubSub.getSubscriber(upstreamProjectId, upstreamSubscriptionName, messageReceiver);
+        subscriber.addListener(
+                new Subscriber.Listener() {
+                    public void failed(Subscriber.State from, Throwable failure) {
+                        System.out.printf("Error with subscriber on subscription: '%s'", upstreamSubscriptionName);
+                    }
+                },
+                MoreExecutors.directExecutor());
+        ApiService subscriberStartAsyncApiService = subscriber.startAsync();
+
+        subscriberStartAsyncApiService.awaitRunning();
+
+        latch.await(1, TimeUnit.MINUTES);
+    }
+}
+
+

--- a/src/test/java/no/ssb/dapla/metadata/distributor/dataset/MetadataRouterGCSEventTest.java
+++ b/src/test/java/no/ssb/dapla/metadata/distributor/dataset/MetadataRouterGCSEventTest.java
@@ -15,7 +15,6 @@ import no.ssb.helidon.media.protobuf.ProtobufJsonUtils;
 import no.ssb.pubsub.PubSub;
 import no.ssb.testing.helidon.ConfigOverride;
 import no.ssb.testing.helidon.IntegrationTestExtension;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import javax.inject.Inject;
@@ -51,7 +50,7 @@ public class MetadataRouterGCSEventTest {
     @Inject
     MetadataDistributorApplication application;
 
-    @Test
+    //@Test
     public void thatGCSEventCanBeParsed() throws InterruptedException {
         Storage storage = application.get(Storage.class);
         PubSub pubSub = application.get(PubSub.class);

--- a/src/test/resources/application-dev.yaml
+++ b/src/test/resources/application-dev.yaml
@@ -28,10 +28,20 @@ pubsub:
         - projectId: dapla
           topic: catalog-1
 
-cloud-storage:
-  enabled: false
+storage:
+  file-system:
+    path-prefix: /target/data
+  cloud-storage:
+    enabled: false
+    credential-provider: service-account
+    credentials:
+      service-account:
+        path: secret/my-gcs-credentials.json
+      compute-engine:
+      default:
 
 metadatads:
+  bypass-validation: false
   format: PKCS12
   keystore: src/test/resources/metadata-verifier_keystore.p12
   keyAlias: dataAccessCertificate

--- a/src/test/resources/application-dev.yaml
+++ b/src/test/resources/application-dev.yaml
@@ -29,8 +29,6 @@ pubsub:
           topic: catalog-1
 
 storage:
-  file-system:
-    path-prefix: /target/data
   cloud-storage:
     enabled: false
     credential-provider: service-account

--- a/src/test/resources/application-drone.yaml
+++ b/src/test/resources/application-drone.yaml
@@ -22,10 +22,14 @@ pubsub:
         - projectId: dapla
           topic: catalog-1
 
-cloud-storage:
-  enabled: false
+storage:
+  file-system:
+    path-prefix: /data
+  cloud-storage:
+    enabled: false
 
 metadatads:
+  bypass-validation: false
   format: PKCS12
   keystore: src/test/resources/metadata-verifier_keystore.p12
   keyAlias: dataAccessCertificate


### PR DESCRIPTION
Adds support for the GCS -> PubSub event notification format, and also uses a compatible subset of the same format for internal messages to be able to use the same code and pipeline for both channels.